### PR TITLE
Changed menu item buttons style

### DIFF
--- a/frontend/src/components/MenuContainer/MenuContainer.tsx
+++ b/frontend/src/components/MenuContainer/MenuContainer.tsx
@@ -15,8 +15,15 @@ type Props = {
 };
 
 const MenuButton = styled((props: ButtonProps) => (
-  <Button variant="outlined" {...props} />
-))({});
+  <Button variant="contained" {...props} />
+))({
+  backgroundColor: "#b26500",
+  fontSize: "1.25rem",
+  fontWeight: "700",
+  "&:hover": {
+    backgroundColor: "#7c4600",
+  },
+});
 
 function MenuContainer({
   rowSpacing,

--- a/frontend/src/pages/TestPage/TestPage.tsx
+++ b/frontend/src/pages/TestPage/TestPage.tsx
@@ -397,9 +397,9 @@ function TestPage() {
       />
       <MenuContainer
         handleClick={onMenuClick}
-        rowSpacing={100}
-        buttonWidth={100}
-        buttonHeight={100}
+        rowSpacing={50}
+        buttonWidth={50}
+        buttonHeight={70}
       />
 
       <FoodOptionsContainer


### PR DESCRIPTION
Title is self-explanatory.

Below is the updated style.
<img width="247" alt="Screenshot 2022-10-10 오후 1 34 07" src="https://user-images.githubusercontent.com/68981068/194786616-c0faae77-e299-4f57-a04e-283ecf2a8b0c.png">
